### PR TITLE
Pipeline updates for configurable splits and model registry

### DIFF
--- a/src/config/model_config.py
+++ b/src/config/model_config.py
@@ -7,6 +7,16 @@ TEST_SIZE = 0.20
 RANDOM_STATE = 42
 TARGET_COLUMN = 'team1_win'
 
+# Data years configuration
+DATA_YEARS = {
+    'train': [2018, 2019, 2020, 2021],
+    'eval': [2022],
+    'test': [2023],
+}
+
+# Models configuration
+MODELS_TO_TRAIN = ['rf', 'xgb', 'svm', 'mlp']
+
 # Model hyperparameters
 RANDOM_FOREST_PARAMS = {
     'n_estimators': 100,
@@ -49,8 +59,8 @@ XGBOOST_PARAMS = {
 
 # Dictionary mapping model names to their parameters
 MODEL_PARAMS = {
-    'Random Forest': RANDOM_FOREST_PARAMS,
-    'SVM': SVM_PARAMS,
-    'MLP': MLP_PARAMS,
-    'XGBoost': XGBOOST_PARAMS
-} 
+    'rf': RANDOM_FOREST_PARAMS,
+    'svm': SVM_PARAMS,
+    'mlp': MLP_PARAMS,
+    'xgb': XGBOOST_PARAMS,
+}

--- a/src/evaluation/compare_runs.py
+++ b/src/evaluation/compare_runs.py
@@ -1,0 +1,79 @@
+"""Compare recent MLflow runs by metrics."""
+import argparse
+from pathlib import Path
+from datetime import datetime
+import pandas as pd
+import mlflow
+
+METRIC_COLUMNS = [
+    'roc_auc',
+    'log_loss',
+    'brier_score',
+    'accuracy',
+    'calibration_error',
+]
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Compare recent MLflow runs")
+    parser.add_argument('--experiment-name', default='NFL_Game_Outcome_Prediction')
+    parser.add_argument('--split-id', required=True)
+    parser.add_argument('--feature-hash', required=True)
+    parser.add_argument('-n', '--num-runs', type=int, default=5)
+    parser.add_argument('--baseline-run-id', type=str, default=None)
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    exp = mlflow.get_experiment_by_name(args.experiment_name)
+    if exp is None:
+        raise ValueError(f"Experiment {args.experiment_name} not found")
+
+    filter_str = f"tags.split_id = '{args.split_id}' and tags.feature_hash = '{args.feature_hash}'"
+    runs = mlflow.search_runs(experiment_ids=[exp.experiment_id],
+                              filter_string=filter_str,
+                              order_by=['start_time DESC'],
+                              max_results=args.num_runs)
+
+    if runs.empty:
+        print("No runs found matching criteria")
+        return
+
+    runs = runs[runs['tags.model'].notna()]
+
+    records = []
+    for _, row in runs.iterrows():
+        record = {
+            'run_id': row['run_id'],
+            'model': row['tags.model'],
+        }
+        for m in METRIC_COLUMNS:
+            record[m] = row.get(f'metrics.{m}')
+        record['run_type'] = row.get('tags.run_type')
+        records.append(record)
+
+    df = pd.DataFrame(records)
+    baseline_df = df[df['run_type'] == 'baseline'].groupby('model').first()[METRIC_COLUMNS]
+
+    comparison_rows = []
+    for run_id, group in df.groupby('run_id'):
+        metrics = group.set_index('model')[METRIC_COLUMNS]
+        deltas = metrics - baseline_df
+        deltas = deltas.add_prefix('delta_')
+        combined = pd.concat([metrics, deltas], axis=1)
+        combined['run_id'] = run_id
+        comparison_rows.append(combined.reset_index())
+
+    comparison = pd.concat(comparison_rows, ignore_index=True)
+    print(comparison)
+
+    reports_dir = Path('reports')
+    reports_dir.mkdir(exist_ok=True)
+    out_path = reports_dir / f"run_comparison_{datetime.utcnow().strftime('%Y%m%d_%H%M%S')}.csv"
+    comparison.to_csv(out_path, index=False)
+    print(f"Saved comparison to {out_path}")
+
+
+if __name__ == '__main__':
+    main()

--- a/src/evaluation/metrics_calculator.py
+++ b/src/evaluation/metrics_calculator.py
@@ -1,21 +1,39 @@
-from sklearn.metrics import accuracy_score, precision_score, recall_score, f1_score
+from sklearn.metrics import (
+    accuracy_score,
+    precision_score,
+    recall_score,
+    f1_score,
+    roc_auc_score,
+    log_loss,
+    brier_score_loss,
+)
+import numpy as np
 
-def calculate_classification_metrics(y_test, y_pred):
-    """
-    Calculate classification metrics for model evaluation.
-    
-    Args:
-        y_test: True labels
-        y_pred: Predicted labels
-        
-    Returns:
-        dict: Dictionary containing accuracy, precision, recall, and f1 score
+def calculate_classification_metrics(y_true, y_pred, y_proba):
+    """Calculate classification metrics for model evaluation.
+
+    Parameters
+    ----------
+    y_true : array-like
+        True labels.
+    y_pred : array-like
+        Predicted class labels.
+    y_proba : array-like
+        Predicted probabilities for the positive class.
+
+    Returns
+    -------
+    dict
+        Dictionary containing evaluation metrics.
     """
     metrics = {
-        'accuracy': accuracy_score(y_test, y_pred),
-        'precision': precision_score(y_test, y_pred, zero_division=0),
-        'recall': recall_score(y_test, y_pred, zero_division=0),
-        'f1': f1_score(y_test, y_pred, zero_division=0)
+        'accuracy': accuracy_score(y_true, y_pred),
+        'precision': precision_score(y_true, y_pred, zero_division=0),
+        'recall': recall_score(y_true, y_pred, zero_division=0),
+        'f1': f1_score(y_true, y_pred, zero_division=0),
+        'roc_auc': roc_auc_score(y_true, y_proba),
+        'log_loss': log_loss(y_true, y_proba),
+        'brier_score': brier_score_loss(y_true, y_proba),
+        'calibration_error': np.mean(np.abs(y_true - y_proba)),
     }
-    
-    return metrics 
+    return metrics

--- a/src/main_mlflow.py
+++ b/src/main_mlflow.py
@@ -2,6 +2,10 @@ import os
 import argparse
 import tempfile
 import json
+import hashlib
+import subprocess
+from pathlib import Path
+
 import pandas as pd
 import mlflow
 import mlflow.sklearn
@@ -10,20 +14,21 @@ import matplotlib.pyplot as plt
 from datetime import datetime
 from mlflow.models.signature import infer_signature
 
-# --- Your existing imports ---
 from preprocessing.load_data import load_nfl_data
-from preprocessing.prepare_data import split_and_prepare_data, scale_features
-from models.random_forest_model import create_rf_model, train_model as train_rf
-from models.svm_model import create_svm_model, train_model as train_svm
-from models.mlp_model import create_mlp_model, train_model as train_mlp
-from models.xgboost_model import create_xgb_model, train_model as train_xgb
+from preprocessing.prepare_data import scale_features
+from models.registry import get_model
 from evaluation.metrics_calculator import calculate_classification_metrics
 from evaluation.plotting import (
     plot_confusion_matrix_heatmap,
     plot_roc_auc_curve,
     plot_model_feature_importances
 )
-from config.model_config import MODEL_PARAMS, TEST_SIZE, RANDOM_STATE, TARGET_COLUMN
+from config.model_config import (
+    DATA_YEARS,
+    MODELS_TO_TRAIN,
+    MODEL_PARAMS,
+    TARGET_COLUMN,
+)
 
 # --- MODIFIED save_plot_to_temp ---
 # This function now creates a figure and an Axes object, and passes the Axes
@@ -70,6 +75,18 @@ def parse_args():
     parser.add_argument('--experiment-name', type=str,
                         default='NFL_Game_Outcome_Prediction',
                         help='Name of the MLflow experiment')
+    parser.add_argument('--train-years', type=str, default=None,
+                        help='Comma-separated list of training years')
+    parser.add_argument('--eval-years', type=str, default=None,
+                        help='Comma-separated list of evaluation years')
+    parser.add_argument('--test-years', type=str, default=None,
+                        help='Comma-separated list of test years')
+    parser.add_argument('--models', type=str, default=None,
+                        help='Comma-separated list of models to train')
+    parser.add_argument('--run-type', type=str, default='baseline',
+                        help='Tag describing the run type')
+    parser.add_argument('--split-id', type=str, default=None,
+                        help='Optional predefined split identifier')
     return parser.parse_args()
 
 def main():
@@ -78,126 +95,152 @@ def main():
     try:
         mlflow.set_experiment(args.experiment_name)
 
+        train_years = list(map(int, args.train_years.split(','))) if args.train_years else DATA_YEARS['train']
+        eval_years = list(map(int, args.eval_years.split(','))) if args.eval_years else DATA_YEARS['eval']
+        test_years = list(map(int, args.test_years.split(','))) if args.test_years else DATA_YEARS['test']
+        models_to_train = args.models.split(',') if args.models else MODELS_TO_TRAIN
+
         with mlflow.start_run(run_name=f"Full_Pipeline_{datetime.now().strftime('%Y%m%d_%H%M%S')}") as parent_run:
-            mlflow.log_params({
-                "test_size": TEST_SIZE,
-                "random_state": RANDOM_STATE,
-                "target_column": TARGET_COLUMN
-            })
+            run_id = parent_run.info.run_id
+
+            split_descriptor = json.dumps({'train': train_years, 'eval': eval_years, 'test': test_years}, sort_keys=True)
+            split_id = args.split_id or hashlib.md5(split_descriptor.encode()).hexdigest()[:8]
+
+            os.makedirs('data/splits', exist_ok=True)
+            with open(f'data/splits/{run_id}.json', 'w') as f:
+                json.dump({'train': train_years, 'eval': eval_years, 'test': test_years}, f, indent=2)
 
             print("Loading NFL data...")
-            df_combined = load_nfl_data()
+            df_combined = load_nfl_data(years=train_years + eval_years + test_years)
             mlflow.log_param("dataset_shape", str(df_combined.shape))
 
-            print("\nPreparing data...")
-            X_train, X_test, y_train, y_test, feature_names = split_and_prepare_data(
-                df_combined,
-                target_column=TARGET_COLUMN,
-                test_size=TEST_SIZE,
-                random_state=RANDOM_STATE
-            )
+            train_df = df_combined[df_combined['season'].isin(train_years)].copy()
+            eval_df = df_combined[df_combined['season'].isin(eval_years)].copy()
+            test_df = df_combined[df_combined['season'].isin(test_years)].copy()
 
-            # Convert to DataFrames and ensure float columns
-            X_train_df = pd.DataFrame(X_train, columns=feature_names)
-            X_test_df = pd.DataFrame(X_test, columns=feature_names)
-            X_train_df = ensure_float_columns(X_train_df)
-            X_test_df = ensure_float_columns(X_test_df)
+            metadata_cols = ['season', 'week', 'kickoff_ts', 'home_team', 'away_team']
+            feature_cols = [c for c in train_df.columns if c not in metadata_cols + [TARGET_COLUMN]]
+
+            feature_hash = hashlib.md5(','.join(sorted(feature_cols)).encode()).hexdigest()[:8]
+            data_snapshot_ts = datetime.utcnow().isoformat()
+            code_commit = subprocess.check_output(['git', 'rev-parse', 'HEAD']).decode().strip()
+
+            def enrich(df: pd.DataFrame) -> pd.DataFrame:
+                df = df.copy()
+                for col in metadata_cols:
+                    if col not in df.columns:
+                        df[col] = pd.NA
+                df['feature_config_hash'] = feature_hash
+                df['data_snapshot_ts'] = data_snapshot_ts
+                df['code_commit'] = code_commit
+                df['split_id'] = split_id
+                return df
+
+            train_df_meta = enrich(train_df)
+            eval_df_meta = enrich(eval_df)
+            test_df_meta = enrich(test_df)
+
+            out_dir = Path('data/processed') / run_id
+            out_dir.mkdir(parents=True, exist_ok=True)
+            train_df_meta.to_parquet(out_dir / 'train.parquet', index=False)
+            eval_df_meta.to_parquet(out_dir / 'eval.parquet', index=False)
+            test_df_meta.to_parquet(out_dir / 'test.parquet', index=False)
+
+            X_train = ensure_float_columns(train_df_meta[feature_cols])
+            y_train = train_df_meta[TARGET_COLUMN]
+            X_eval = ensure_float_columns(eval_df_meta[feature_cols])
+            y_eval = eval_df_meta[TARGET_COLUMN]
+
+            mlflow.set_tags({
+                'run_type': args.run_type,
+                'split_id': split_id,
+                'feature_hash': feature_hash,
+                'years_train': ','.join(map(str, train_years)),
+                'years_eval': ','.join(map(str, eval_years)),
+                'models': ','.join(models_to_train),
+            })
 
             results = {}
-            model_functions = {
-                'Random Forest': (create_rf_model, train_rf),
-                'SVM': (create_svm_model, train_svm),
-                'MLP': (create_mlp_model, train_mlp),
-                'XGBoost': (create_xgb_model, train_xgb)
-            }
+            model_name_map = {'rf': 'Random Forest', 'svm': 'SVM', 'mlp': 'MLP', 'xgb': 'XGBoost'}
 
-            for model_name, (create_func, train_func) in model_functions.items():
-                print(f"\n--- Training {model_name} Model ---")
+            for model_key in models_to_train:
+                readable_name = model_name_map.get(model_key, model_key)
+                print(f"\n--- Training {readable_name} Model ---")
 
-                with mlflow.start_run(run_name=f"{model_name}_{datetime.now().strftime('%Y%m%d_%H%M%S')}",
-                                      nested=True) as child_run:
-                    mlflow.log_params(MODEL_PARAMS[model_name])
+                model, train_func = get_model(model_key)
 
-                    model = create_func(MODEL_PARAMS[model_name])
-
-                    if model_name == 'SVM':
-                        # Scale features while preserving DataFrame structure
-                        X_train_scaled, X_test_scaled, _ = scale_features(X_train_df.values, X_test_df.values)
-                        X_train_scaled_df = pd.DataFrame(X_train_scaled, columns=feature_names)
-                        X_test_scaled_df = pd.DataFrame(X_test_scaled, columns=feature_names)
-                        
-                        model = train_func(model, X_train_scaled_df, y_train)
-                        y_pred = model.predict(X_test_scaled_df)
-                        y_pred_proba = model.predict_proba(X_test_scaled_df)[:, 1]
-                        
-                        input_example_df = X_train_scaled_df.head()
-                        signature_input_data = X_train_scaled_df.head()
-                        predictions_for_signature = model.predict(X_test_scaled_df.head())
-                    else:
+                with mlflow.start_run(
+                    run_name=f"{readable_name}_{datetime.now().strftime('%Y%m%d_%H%M%S')}",
+                    nested=True,
+                ) as child_run:
+                    mlflow.set_tags({'model': model_key, 'split_id': split_id, 'feature_hash': feature_hash, 'run_type': args.run_type})
+                    mlflow.log_params(MODEL_PARAMS[model_key])
+                    if model_key == 'svm':
+                        X_train_scaled, X_eval_scaled, _ = scale_features(X_train.values, X_eval.values)
+                        X_train_df = pd.DataFrame(X_train_scaled, columns=feature_cols)
+                        X_eval_df = pd.DataFrame(X_eval_scaled, columns=feature_cols)
                         model = train_func(model, X_train_df, y_train)
-                        y_pred = model.predict(X_test_df)
-                        y_pred_proba = model.predict_proba(X_test_df)[:, 1]
-                        
+                        y_pred = model.predict(X_eval_df)
+                        y_pred_proba = model.predict_proba(X_eval_df)[:, 1]
                         input_example_df = X_train_df.head()
                         signature_input_data = X_train_df.head()
-                        predictions_for_signature = model.predict(X_test_df.head())
+                        predictions_for_signature = model.predict(X_eval_df.head())
+                    else:
+                        model = train_func(model, X_train, y_train)
+                        y_pred = model.predict(X_eval)
+                        y_pred_proba = model.predict_proba(X_eval)[:, 1]
+                        input_example_df = X_train.head()
+                        signature_input_data = X_train.head()
+                        predictions_for_signature = model.predict(X_eval.head())
 
-                    metrics = calculate_classification_metrics(y_test, y_pred)
+                    metrics = calculate_classification_metrics(y_eval, y_pred, y_pred_proba)
                     mlflow.log_metrics(metrics)
-                    results[model_name] = metrics
+                    results[readable_name] = metrics
 
-                    print(f"\n--- {model_name} Model Evaluation Metrics: ---")
+                    print(f"\n--- {readable_name} Model Evaluation Metrics: ---")
                     for metric_name, value in metrics.items():
                         print(f"{metric_name.capitalize()}: {value:.4f}")
 
-                    # --- Infer model signature ---
                     signature = infer_signature(signature_input_data, predictions_for_signature)
 
-                    # --- Save and log plots ---
-                    # IMPORTANT: Ensure your plotting functions in src/evaluation/plotting.py
-                    # are modified to accept 'ax' as a keyword argument and draw on it.
-                    # They should NOT call plt.figure(), plt.show(), or plt.close().
-                    cm_path = save_plot_to_temp(plot_confusion_matrix_heatmap, y_test, y_pred, model_name)
-                    mlflow.log_artifact(cm_path, "plots")
+                    cm_path = save_plot_to_temp(plot_confusion_matrix_heatmap, y_eval, y_pred, readable_name)
+                    mlflow.log_artifact(cm_path, 'plots')
                     os.unlink(cm_path)
 
-                    roc_path = save_plot_to_temp(plot_roc_auc_curve, y_test, y_pred_proba, model_name)
-                    mlflow.log_artifact(roc_path, "plots")
+                    roc_path = save_plot_to_temp(plot_roc_auc_curve, y_eval, y_pred_proba, readable_name)
+                    mlflow.log_artifact(roc_path, 'plots')
                     os.unlink(roc_path)
 
-                    fi_path = save_plot_to_temp(plot_model_feature_importances, model, feature_names, model_name)
-                    mlflow.log_artifact(fi_path, "plots")
+                    fi_path = save_plot_to_temp(plot_model_feature_importances, model, feature_cols, readable_name)
+                    mlflow.log_artifact(fi_path, 'plots')
                     os.unlink(fi_path)
 
-                    # --- Log the model WITH signature and input example ---
-                    if model_name == 'XGBoost':
+                    if model_key == 'xgb':
                         mlflow.xgboost.log_model(
                             xgb_model=model,
-                            artifact_path="model",
+                            artifact_path='model',
                             signature=signature,
                             input_example=input_example_df
                         )
-                    else: # For RF, SVM, MLP
+                    else:
                         mlflow.sklearn.log_model(
                             sk_model=model,
-                            artifact_path="model",
+                            artifact_path='model',
                             signature=signature,
                             input_example=input_example_df
                         )
 
-                    # --- Save and log run configuration for this child run ---
                     run_config_payload = {
-                        "model_name": model_name,
-                        "model_params": MODEL_PARAMS[model_name],
-                        "metrics_from_run": metrics
+                        'model_name': readable_name,
+                        'model_params': MODEL_PARAMS[model_key],
+                        'metrics_from_run': metrics,
                     }
                     with tempfile.NamedTemporaryFile(mode='w+', suffix='.json', delete=False) as tmp_config_file:
                         json.dump(run_config_payload, tmp_config_file, indent=2)
                         config_file_path = tmp_config_file.name
-                    mlflow.log_artifact(config_file_path, "config")
+                    mlflow.log_artifact(config_file_path, 'config')
                     os.unlink(config_file_path)
 
-            # --- After the loop, for the PARENT run ---
             print("\n--- Final Model Comparison (Logging to Parent Run) ---")
             comparison_df = pd.DataFrame(results).T
             comparison_df.index.name = 'model_name'
@@ -206,7 +249,7 @@ def main():
             with tempfile.NamedTemporaryFile(mode='w+', suffix='.csv', delete=False) as tmp_comparison_file:
                 comparison_df.to_csv(tmp_comparison_file.name)
                 comparison_file_path = tmp_comparison_file.name
-            mlflow.log_artifact(comparison_file_path, "comparison_results")
+            mlflow.log_artifact(comparison_file_path, 'comparison_results')
             os.unlink(comparison_file_path)
 
     except Exception as e:

--- a/src/models/registry.py
+++ b/src/models/registry.py
@@ -1,0 +1,41 @@
+"""Model registry mapping names to constructors and train functions."""
+from typing import Tuple, Callable, Any, Dict
+
+from .random_forest_model import create_rf_model, train_model as train_rf
+from .xgboost_model import create_xgb_model, train_model as train_xgb
+from .svm_model import create_svm_model, train_model as train_svm
+from .mlp_model import create_mlp_model, train_model as train_mlp
+from config.model_config import MODEL_PARAMS
+
+# Mapping of short model keys to (create_function, train_function)
+MODEL_REGISTRY: Dict[str, Tuple[Callable[..., Any], Callable[..., Any]]] = {
+    "rf": (create_rf_model, train_rf),
+    "xgb": (create_xgb_model, train_xgb),
+    "svm": (create_svm_model, train_svm),
+    "mlp": (create_mlp_model, train_mlp),
+}
+
+
+def get_model(name: str, **kwargs) -> Tuple[Any, Callable[..., Any]]:
+    """Instantiate a model by name and return it with its training function.
+
+    Parameters
+    ----------
+    name: str
+        Registry key of the model to create.
+    **kwargs: dict
+        Additional keyword arguments to override default hyperparameters.
+
+    Returns
+    -------
+    tuple
+        (model_instance, train_function)
+    """
+    if name not in MODEL_REGISTRY:
+        raise KeyError(f"Model '{name}' not found in registry")
+
+    create_func, train_func = MODEL_REGISTRY[name]
+    params = MODEL_PARAMS.get(name, {}).copy()
+    params.update(kwargs)
+    model = create_func(params)
+    return model, train_func

--- a/src/preprocessing/load_data.py
+++ b/src/preprocessing/load_data.py
@@ -1,11 +1,25 @@
 import os
 import pandas as pd
 from glob import glob
+import re
+from typing import Iterable, Optional
 
-def load_nfl_data(data_dir='data/processed'):
-    """
-    Loads all 'final-<year>.csv' files from subdirectories in the given data_dir.
-    Returns a single combined DataFrame if all files have matching columns.
+
+def load_nfl_data(data_dir: str = 'data/processed', years: Optional[Iterable[int]] = None) -> pd.DataFrame:
+    """Load all ``final-<year>.csv`` files for the requested years.
+
+    Parameters
+    ----------
+    data_dir: str
+        Base directory containing year subdirectories with ``final-<year>.csv`` files.
+    years: Iterable[int], optional
+        If provided, only files whose season matches one of these years will be
+        loaded.
+
+    Returns
+    -------
+    pd.DataFrame
+        Combined data for the selected seasons with a ``season`` column added.
     """
     combined_df = pd.DataFrame()
     file_paths = glob(os.path.join(data_dir, '*', 'final-*.csv'))
@@ -14,8 +28,14 @@ def load_nfl_data(data_dir='data/processed'):
     columns_set = None
 
     for file_path in sorted(file_paths):
+        match = re.search(r'final-(\d{4})', os.path.basename(file_path))
+        year = int(match.group(1)) if match else None
+        if years is not None and year not in years:
+            continue
+
         try:
             df = pd.read_csv(file_path)
+            df['season'] = year
             print(f"Loaded {file_path}, shape: {df.shape}")
 
             if columns_set is None:
@@ -37,4 +57,4 @@ def load_nfl_data(data_dir='data/processed'):
     else:
         print("\nNo valid data files loaded.")
 
-    return combined_df 
+    return combined_df


### PR DESCRIPTION
## Summary
- add year- and model-selection options to config and CLI, logging chosen splits for reproducible runs
- introduce central model registry and update training scripts to iterate over requested models only
- record rich dataset metadata and standard MLflow tags, and provide compare_runs utility to review recent runs

## Testing
- `python src/main_mlflow.py --experiment-name temp_exp --train-years 2018,2019 --eval-years 2020 --test-years 2021 --models rf,svm --run-type baseline`
- `python src/main_mlflow.py --experiment-name temp_exp --train-years 2018,2019 --eval-years 2020 --test-years 2021 --models rf --run-type kats_pack1`
- `python src/evaluation/compare_runs.py --experiment-name temp_exp --split-id 51c691d0 --feature-hash 789f62fb -n 10`


------
https://chatgpt.com/codex/tasks/task_e_6898dafbdba8832aa1a241c0519d5cb4